### PR TITLE
Support (optional) argument for test/module name pattern.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from distutils.core import setup
 
 setup(name='testflo',
-      version='1.1',
+      version='1.2',
       description="A simple flow based testing framework",
       license='Apache 2.0',
       install_requires=[

--- a/testflo/main.py
+++ b/testflo/main.py
@@ -132,8 +132,7 @@ skip_dirs=site-packages,
         benchmark_file = open(options.benchmarkfile, 'a')
     else:
         discoverer = TestDiscoverer(dir_exclude=dir_exclude,
-                                    func_pattern=six.text_type(options.test_glob),
-                                    module_pattern=six.text_type(options.test_glob + '.py'))
+                                    func_pattern=six.text_type(options.test_glob))
         benchmark_file = open(os.devnull, 'a')
 
     retval = 0

--- a/testflo/main.py
+++ b/testflo/main.py
@@ -131,7 +131,9 @@ skip_dirs=site-packages,
                                     dir_exclude=dir_exclude)
         benchmark_file = open(options.benchmarkfile, 'a')
     else:
-        discoverer = TestDiscoverer(dir_exclude=dir_exclude)
+        discoverer = TestDiscoverer(dir_exclude=dir_exclude,
+                                    func_pattern=six.text_type(options.test_glob),
+                                    module_pattern=six.text_type(options.test_glob + '.py'))
         benchmark_file = open(os.devnull, 'a')
 
     retval = 0

--- a/testflo/util.py
+++ b/testflo/util.py
@@ -109,6 +109,10 @@ def _get_parser():
     parser.add_argument('tests', metavar='test', nargs='*',
                         help='A test method, test case, module, or directory to run.')
 
+    parser.add_argument('-m', '--match', '--testmatch', action='store', dest='test_glob',
+                        metavar='GLOB', help='Pattern to use for test discovery.',
+                        default='test*')
+
     return parser
 
 def _get_testflo_subproc_args():


### PR DESCRIPTION
Supports pattern matching (a la fnmatch) with `-m`, `--match`, or `--testmatch`.