### PR TITLE
py3 compatibility fix

### DIFF
--- a/testflo/test.py
+++ b/testflo/test.py
@@ -3,7 +3,6 @@ import sys
 import time
 import traceback
 from inspect import isclass
-import pickle
 from subprocess import Popen, PIPE
 
 from types import FunctionType, ModuleType
@@ -163,7 +162,8 @@ class Test(object):
 
         add_queue_to_env(queue)
 
-        p = Popen(cmd, stdout=PIPE, stderr=PIPE, env=os.environ)
+        p = Popen(cmd, stdout=PIPE, stderr=PIPE, env=os.environ,
+                  universal_newlines=True)  # text mode
         out, err = p.communicate()
         if self.nocapture:
             sys.stdout.write(out)
@@ -193,7 +193,8 @@ class Test(object):
 
             add_queue_to_env(queue)
 
-            p = Popen(cmd, stdout=PIPE, stderr=PIPE, env=os.environ)
+            p = Popen(cmd, stdout=PIPE, stderr=PIPE, env=os.environ,
+                      universal_newlines=True)  # text mode
             out, err = p.communicate()
             if self.nocapture:
                 sys.stdout.write(out)


### PR DESCRIPTION
add `universal_newlines` arg to `Popen` so `out` and `err` will be string rather than bytes
otherwise py3 will complain: "write() argument must be str, not bytes"