### PR TITLE
Expected fail ok

### DIFF
--- a/testflo/main.py
+++ b/testflo/main.py
@@ -74,7 +74,7 @@ def run_pipeline(source, pipe):
 
     # iterate over the last iter in the pipline and we're done
     for result in iters[-1]:
-        if result.status == 'FAIL':
+        if result.status == 'FAIL' and not result.expected_fail:
             return_code = 1
 
     return return_code

--- a/testflo/test.py
+++ b/testflo/test.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os
 import sys
 import time
@@ -166,8 +168,8 @@ class Test(object):
         p = Popen(cmd, stdout=PIPE, stderr=PIPE, env=os.environ)
         out, err = p.communicate()
         if self.nocapture:
-            sys.stdout.write(out)
-            sys.stderr.write(err)
+            if out: print(out)
+            if err: print(err)
 
         os.environ['TESTFLO_QUEUE'] = ''
 
@@ -196,8 +198,8 @@ class Test(object):
             p = Popen(cmd, stdout=PIPE, stderr=PIPE, env=os.environ)
             out, err = p.communicate()
             if self.nocapture:
-                sys.stdout.write(out)
-                sys.stderr.write(err)
+                if out: print(out)
+                if err: print(err)
 
             os.environ['TESTFLO_QUEUE'] = ''
 


### PR DESCRIPTION
If a user decorates a test with `@unittest.expectedFailure` then a failure of that test will not cause testflo to return -1 (and thus trigger a failure of the tests on CI)