### PR TITLE
a few small improvements

### DIFF
--- a/testflo/main.py
+++ b/testflo/main.py
@@ -177,13 +177,13 @@ skip_dirs=site-packages,
                 verbose = int(options.verbose)
 
             pipeline.extend([
-                ResultPrinter(verbose=verbose).get_iter,
+                ResultPrinter(options, verbose=verbose).get_iter,
                 ResultSummary(options).get_iter,
             ])
             if not options.noreport:
                 # print verbose results and summary to a report file
                 pipeline.extend([
-                    ResultPrinter(report, verbose=1).get_iter,
+                    ResultPrinter(options, report, verbose=1).get_iter,
                     ResultSummary(options, stream=report).get_iter,
                 ])
 

--- a/testflo/printer.py
+++ b/testflo/printer.py
@@ -22,8 +22,9 @@ class ResultPrinter(object):
     still displayed in verbose form.
     """
 
-    def __init__(self, stream=sys.stdout, verbose=0):
+    def __init__(self, options, stream=sys.stdout, verbose=0):
         self.stream = stream
+        self.options = options
         self.verbose = verbose
 
     def get_iter(self, input_iter):
@@ -65,5 +66,7 @@ class ResultPrinter(object):
                                                     stats, result.memory_usage))
         else:
             stream.write(_result_map[(result.status, result.expected_fail)])
+            if self.options.pre_announce:
+                stream.write('\n')
 
         stream.flush()

--- a/testflo/runner.py
+++ b/testflo/runner.py
@@ -1,6 +1,8 @@
 """
 Methods and class for running tests.
 """
+from __future__ import print_function
+
 import sys
 import os
 

--- a/testflo/runner.py
+++ b/testflo/runner.py
@@ -53,7 +53,7 @@ class TestRunner(object):
             stop = False
             for test in tests:
                 if self.pre_announce:
-                    print("    about to run %s" % test.short_name())
+                    print("    about to run %s " % test.short_name(), end='')
                     sys.stdout.flush()
                 result = test.run(self._queue)
                 yield result

--- a/testflo/summary.py
+++ b/testflo/summary.py
@@ -12,6 +12,12 @@ class ResultSummary(object):
         self.options = options
         self._start_time = time.time()
 
+    def get_test_name(self, test):
+        if self.options.full_path:
+            return test.spec
+        else:
+            return test.short_name()
+
     def get_iter(self, input_iter):
         oks = 0
         total = 0
@@ -26,7 +32,7 @@ class ResultSummary(object):
 
             if test.status == 'OK':
                 if test.expected_fail:
-                    fails.append(test.short_name())
+                    fails.append(self.get_test_name(test))
                 else:
                     oks += 1
                 test_sum_time += (test.end_time-test.start_time)
@@ -34,10 +40,10 @@ class ResultSummary(object):
                 if test.expected_fail:
                     oks += 1
                 else:
-                    fails.append(test.short_name())
+                    fails.append(self.get_test_name(test))
                 test_sum_time += (test.end_time-test.start_time)
             elif test.status == 'SKIP':
-                skips.append(test.short_name())
+                skips.append(self.get_test_name(test))
 
             yield test
 

--- a/testflo/test.py
+++ b/testflo/test.py
@@ -164,11 +164,11 @@ class Test(object):
 
             if self.nocapture:
                 out = sys.stdout
-                err = sys.stderr
             else:
                 out = open(os.devnull, 'w')
-                errfd, tmperr = mkstemp()
-                err = os.fdopen(errfd, 'w')
+
+            errfd, tmperr = mkstemp()
+            err = os.fdopen(errfd, 'w')
 
             p = Popen(cmd, stdout=out, stderr=err, env=os.environ,
                       universal_newlines=True)  # text mode
@@ -187,13 +187,11 @@ class Test(object):
                     time.sleep(poll_interval)
                     count += 1
 
-            if self.nocapture:
-                errmsg = ''
-            else:
-                err.close()
-                with open(tmperr, 'r') as f:
-                    errmsg = f.read()
-                os.remove(tmperr)
+            err.close()
+
+            with open(tmperr, 'r') as f:
+                errmsg = f.read()
+            os.remove(tmperr)
 
             os.environ['TESTFLO_QUEUE'] = ''
 
@@ -214,13 +212,13 @@ class Test(object):
             self.status = 'FAIL'
             self.err_msg = traceback.format_exc()
             result = self
+
+            err.close()
         finally:
-            if self.nocapture:
-                sys.stdout.flush()
-                sys.stderr.flush()
-            else:
+            if not self.nocapture:
                 out.close()
-                err.close()
+            sys.stdout.flush()
+            sys.stderr.flush()
 
         return result
 
@@ -321,10 +319,9 @@ class Test(object):
 
             if self.nocapture:
                 outstream = sys.stdout
-                errstream = sys.stderr
             else:
                 outstream = DevNull()
-                errstream = cStringIO()
+            errstream = cStringIO()
 
             done = False
             expected = expected2 = expected3 = False
@@ -382,10 +379,7 @@ class Test(object):
 
                 self.end_time = time.time()
                 self.status = status
-                if self.nocapture:
-                    self.err_msg = ""
-                else:
-                    self.err_msg = errstream.getvalue()
+                self.err_msg = errstream.getvalue()
                 self.memory_usage = get_memory_usage()
                 self.expected_fail = expected or expected2 or expected3
 

--- a/testflo/util.py
+++ b/testflo/util.py
@@ -68,6 +68,8 @@ def _get_parser():
                              "can help track down a hanging test. This automatically sets -n 1.")
     parser.add_argument('-f', '--fail', action='store_true', dest='save_fails',
                         help="Save failed tests to failtests.in file.")
+    parser.add_argument('--full_path', action='store_true', dest='full_path',
+                        help="Display full test specs instead of shortened names.")                        
     parser.add_argument('-i', '--isolated', action='store_true', dest='isolated',
                         help="Run each test in a separate subprocess.")
     parser.add_argument('--nompi', action='store_true', dest='nompi',

--- a/testflo/util.py
+++ b/testflo/util.py
@@ -339,6 +339,10 @@ def read_test_file(testfile):
     """Reads a file containing one testspec per line."""
     with open(os.path.abspath(testfile), 'r') as f:
         for line in f:
+            idx = line.find('#')
+            if idx >= 0:
+                line = line[:idx]
+
             line = line.strip()
             if line:
                 yield line

--- a/testflo/util.py
+++ b/testflo/util.py
@@ -79,10 +79,8 @@ def _get_parser():
                         help="Stop after the first test failure, or as soon as possible"
                              " when running concurrent tests.")
     parser.add_argument('-s', '--nocapture', action='store_true', dest='nocapture',
-                        help="stdout and stderr will not be captured and will be"
-                             " written to the screen immediately. It's best to use this with "
-                             "-n 1 or with --pre_announce so the output will be clearly associated"
-                             " with the correct test.")
+                        help="Standard output (stdout) will not be captured and will be"
+                             " written to the screen immediately.")
     parser.add_argument('--coverage', action='store_true', dest='coverage',
                         help="Perform coverage analysis and display results on stdout")
     parser.add_argument('--coverage-html', action='store_true', dest='coveragehtml',


### PR DESCRIPTION
- output from --pre_announce now looks better, with the result ('.', 'S', or 'F') showing on the same line as the "about to run ..." instead of on the following line
- comments are now allowed inside of a test list file
- added a --full_path option so that full testspec paths will be displayed.  Having the full path make it easier to copy and paste the testspec to run testflo on just that single test.