### PR TITLE
 add support for ISOLATED attribute

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,3 +1,8 @@
+testflo version 1.3.2 Release Notes
+Nov 17, 2018
+
+* added support for ISOLATED attribute
+
 testflo version 1.3.1 Release Notes
 Aug 17, 2018
 

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@
 from distutils.core import setup
 
 setup(name='testflo',
-      version='1.3.1',
+      version='1.3.2',
       description="A simple flow-based testing framework",
       long_description="""
         usage: testflo [options]
 
         positional arguments:
           test                  A test method, test case, module, or directory to run.
-        
+
         optional arguments:
           -h, --help            show this help message and exit
           -c FILE, --config FILE

--- a/testflo/test.py
+++ b/testflo/test.py
@@ -280,7 +280,7 @@ class Test(object):
         if queue is not None:
             if MPI is not None and self.mpi and self.nprocs > 0:
                 return self._run_mpi(queue)
-            elif self.isolated:
+            elif self.isolated or self.nprocs > 0:
                 return self._run_isolated(queue)
 
         with TestContext(self):

--- a/testflo/test.py
+++ b/testflo/test.py
@@ -110,7 +110,7 @@ class Test(object):
 
         if not err_msg:
             with TestContext(self):
-                self.mod, self.tcase, self.funcname, self.nprocs = self._get_test_info()
+                self.mod, self.tcase, self.funcname, self.nprocs, self.isolated = self._get_test_info()
         else:
             self.mod = self.tcase = self.funcname = None
 
@@ -131,11 +131,12 @@ class Test(object):
         return iter((self,))
 
     def _get_test_info(self):
-        """Get the test's module, testcase (if any), function name and
-        N_PROCS (for mpi tests).
+        """Get the test's module, testcase (if any), function name,
+        N_PROCS (for mpi tests) and ISOLATED.
         """
         parent = funcname = mod = testcase = None
         nprocs = 0
+        isolated = False
 
         try:
             mod, testcase, funcname = _parse_test_path(self.spec)
@@ -150,10 +151,11 @@ class Test(object):
                 if testcase is not None:
                     parent = testcase
                     nprocs = getattr(testcase, 'N_PROCS', 0)
+                    isolated = getattr(testcase, 'ISOLATED', False)
                 else:
                     parent = mod
 
-        return mod, testcase, funcname, nprocs
+        return mod, testcase, funcname, nprocs, isolated
 
     def _run_sub(self, cmd, queue):
         """
@@ -280,7 +282,7 @@ class Test(object):
         if queue is not None:
             if MPI is not None and self.mpi and self.nprocs > 0:
                 return self._run_mpi(queue)
-            elif self.isolated or self.nprocs > 0:
+            elif self.isolated:
                 return self._run_isolated(queue)
 
         with TestContext(self):

--- a/testflo/test.py
+++ b/testflo/test.py
@@ -98,7 +98,6 @@ class Test(object):
         self.load5m = 0.0
         self.load15m = 0.0
         self.nocapture = options.nocapture
-        self.isolated = options.isolated
         self.mpi = not options.nompi
         self.timeout = options.timeout
         self.expected_fail = False
@@ -110,7 +109,8 @@ class Test(object):
 
         if not err_msg:
             with TestContext(self):
-                self.mod, self.tcase, self.funcname, self.nprocs, self.isolated = self._get_test_info()
+                self.mod, self.tcase, self.funcname, self.nprocs, isolated = self._get_test_info()
+                self.isolated = isolated or options.isolated
         else:
             self.mod = self.tcase = self.funcname = None
 


### PR DESCRIPTION
the `ISOLATED` attribute has the same function as the `-i` option, but for a specific TestCase 
(similar to the N_PROCS attribute for an MPI TestCase)