### PR TITLE
Add new option to turn any skipped tests into nonzero exit code

### DIFF
--- a/testflo/util.py
+++ b/testflo/util.py
@@ -100,6 +100,9 @@ def _get_parser():
     parser.add_argument('--show_skipped', action='store_true', dest='show_skipped',
                         help="Display a list of any skipped tests in the summary.")
 
+    parser.add_argument('--disallow_skipped', action='store_true', dest='disallow_skipped',
+                        help="Return exit code 2 if no tests failed but some tests are skipped.")
+
     parser.add_argument('tests', metavar='test', nargs='*',
                         help='A test method, test case, module, or directory to run. If not '
                              'supplied, the current working directory is assumed.')


### PR DESCRIPTION
Closes #47. This PR adds a new option which will return exit 2 if no tests failed but there are some skipped tests. This is useful in some cases if we expect there to be no skipped tests, as that could indicate some errors with package installation. Regarding the PR, I'm not sure if the name of the command line option is okay so please let me know if there are better alternatives.

Also, would it be possible to make a 1.4.3 release after? I noticed that the version was bumped but no PyPI release exists.