### PR TITLE
fix for bad testcase comm

### DIFF
--- a/testflo/test.py
+++ b/testflo/test.py
@@ -225,13 +225,14 @@ class Test(object):
             return self
 
         MPI = None
-        if queue is not None and self.nprocs > 0 and not self.options.nompi:
+        if self.nprocs > 0 and not self.options.nompi:
             try:
                 from mpi4py import MPI
             except ImportError:
                 pass
             else:
-                return self._run_mpi(queue)
+                if queue is not None:
+                    return self._run_mpi(queue)
         elif self.options.isolated:
             return self._run_isolated(queue)
 


### PR DESCRIPTION
It turns out we weren't setting the comm at the TestCase level properly in procs running under run_mpi.  We didn't see it in our OpenMDAO tests because we don't use that comm.  Tim Brooks was trying to use testflo with one of his MPI tests and his test actually tried to pass the TestCase's comm down into another code and it was just getting a fake comm.