### PR TITLE
setting N_PROCS=1 will now run under MPI

### DIFF
--- a/testflo/__init__.py
+++ b/testflo/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '1.4.7-dev'
+__version__ = '1.4.8-dev'

--- a/testflo/mpirun.py
+++ b/testflo/mpirun.py
@@ -10,6 +10,8 @@ if __name__ == '__main__':
     import os
     import traceback
 
+    os.environ['OPENMDAO_USE_MPI'] = '1'
+
     from mpi4py import MPI
     from testflo.test import Test
     from testflo.cover import setup_coverage, save_coverage


### PR DESCRIPTION
This allows MPI test cases where the number of procs is 1 to work properly in openmdao.  This is needed for the test_petsc_ksp.py module in openmdao, which uses PETSc vectors but only a single proc and is currently always being skipped.  After this fix we can update the test_petsc_ksp.py test cases with N_PROCS=1 and they will work as intended without being skipped.