### PR TITLE
added env var to tell other code when it's running under testflo

### DIFF
--- a/testflo/main.py
+++ b/testflo/main.py
@@ -144,6 +144,9 @@ skip_dirs=site-packages,
                 return True
         return False
 
+    # set this so code will know when it's running under testflo
+    os.environ['TESTFLO_RUNNING'] = '1'
+
     setup_coverage(options)
 
     if options.noreport:


### PR DESCRIPTION
This change was originally in the PR that updates coverage, but that PR is held up because of some issue I haven't had time to look into yet.  But Herb needs this now so I'm just splitting it out into its own PR.