### PR TITLE
Deprecations report

### DIFF
--- a/testflo/deprecations.py
+++ b/testflo/deprecations.py
@@ -64,6 +64,7 @@ class DeprecationsReport(object):
                 for d in sitedirs:
                     if path.startswith(d):
                         path = path[len(d):]
+                        break
             return path
 
         for msg in sorted(deprecations):

--- a/testflo/deprecations.py
+++ b/testflo/deprecations.py
@@ -1,0 +1,66 @@
+import sys
+import os
+
+from io import StringIO
+
+class DeprecationsReport(object):
+    """Generates a report of all Deprecation warnings raised during testing."""
+
+    def __init__(self, options, stream=sys.stdout):
+        self.stream = stream
+        self.options = options
+        self.startdir = os.getcwd()
+
+    def get_iter(self, input_iter):
+
+        deprecations = {}
+
+        for test in input_iter:
+            for msg, locs in test.deprecations.items():
+                deprecations[msg] = deprecations.get(msg, set()) | locs
+            yield test
+
+        report = self.generate_report(deprecations)
+
+        if self.options.show_deprecations:
+            self.stream.write(report)
+
+        if self.options.deprecations_report:
+            with open(self.options.deprecations_report, 'w') as stream:
+                stream.write(report)
+
+    def generate_report(self, deprecations):
+        report = StringIO()
+
+        title = " Deprecations Report "
+        eqs = "=" * 16
+
+        write = report.write
+
+        write("\n{}{}{}\n".format(eqs, title, eqs))
+
+        count = len(deprecations)
+
+        write("\n\n{} unique deprecation warnings were captured{}\n".format(count, ':' if count else '.'))
+
+        if count == 0 and self.options.disallow_deprecations:
+            write("\n\nDeprecation warnings have been raised as Exceptions\n"
+                  "due to the use of the --disallow_deprecations option,\n"
+                  "so no deprecation warnings have been captured.")
+
+        for msg in sorted(deprecations):
+            write("--\n{}\n\n".format(msg))
+            for filename, lineno, test_spec in deprecations[msg]:
+                write("    {}, line {}\n".format(filename, lineno))
+                if test_spec:
+                    if test_spec.startswith(self.startdir):
+                        test_spec = test_spec[len(self.startdir):]
+                    write("    [{}]\n\n".format(test_spec))
+
+        if count > 0:
+            write("\n\nFor a stack trace of reported deprecations, run the\n"
+                  "identified test wth the --disallow_deprecations option.")
+
+        write("\n" + "=" * (len(title) + 2 * len(eqs)) + "\n")
+
+        return report.getvalue()

--- a/testflo/deprecations.py
+++ b/testflo/deprecations.py
@@ -59,7 +59,7 @@ class DeprecationsReport(object):
 
         if count > 0:
             write("\n\nFor a stack trace of reported deprecations, run the\n"
-                  "identified test wth the --disallow_deprecations option.")
+                  "identified test with the --disallow_deprecations option.")
 
         write("\n" + "=" * (len(title) + 2 * len(eqs)) + "\n")
 

--- a/testflo/deprecations.py
+++ b/testflo/deprecations.py
@@ -38,7 +38,7 @@ class DeprecationsReport(object):
 
         write = report.write
 
-        write("\n\n{}\n{}\n\n".format(title, eqs))
+        write("\n{}\n{}\n\n".format(title, eqs))
 
         count = len(deprecations)
 

--- a/testflo/deprecations.py
+++ b/testflo/deprecations.py
@@ -38,11 +38,11 @@ class DeprecationsReport(object):
 
         write = report.write
 
-        write("\n\n{}\n{}\n".format(title, eqs))
+        write("\n\n{}\n{}\n\n".format(title, eqs))
 
         count = len(deprecations)
 
-        write("\n\n{} unique deprecation warnings were captured{}\n\n".format(count, ':' if count else '.'))
+        write("{} unique deprecation warnings were captured{}\n\n".format(count, ':' if count else '.'))
 
         if count == 0 and self.options.disallow_deprecations:
             write("\nDeprecation warnings have been raised as Exceptions\n"

--- a/testflo/deprecations.py
+++ b/testflo/deprecations.py
@@ -33,12 +33,12 @@ class DeprecationsReport(object):
     def generate_report(self, deprecations):
         report = StringIO()
 
-        title = " Deprecations Report "
-        eqs = "=" * 30
+        title = "Deprecations Report"
+        eqs = "=" * len(title)
 
         write = report.write
 
-        write("\n{}{}{}\n".format(eqs, title, eqs))
+        write("\n\n{}\n{}\n".format(title, eqs))
 
         count = len(deprecations)
 
@@ -76,7 +76,5 @@ class DeprecationsReport(object):
         if count > 0:
             write("\n\nFor a stack trace of reported deprecations, run the "
                   "identified test with the --disallow_deprecations option.")
-
-        write("\n" + "=" * (len(title) + 2 * len(eqs)) + "\n")
 
         return report.getvalue()

--- a/testflo/main.py
+++ b/testflo/main.py
@@ -37,6 +37,7 @@ from testflo.runner import ConcurrentTestRunner
 from testflo.printer import ResultPrinter
 from testflo.benchmark import BenchmarkWriter
 from testflo.summary import ResultSummary
+from testflo.deprecations import DeprecationsReport
 from testflo.duration import DurationSummary
 from testflo.discover import TestDiscoverer
 from testflo.filters import TimeFilter, FailFilter
@@ -205,6 +206,9 @@ skip_dirs=site-packages,
             runner = ConcurrentTestRunner(options, queue)
 
             pipeline.append(runner.get_iter)
+
+            if options.show_deprecations or options.deprecations_report:
+                pipeline.append(DeprecationsReport(options).get_iter)
 
             if options.benchmark:
                 pipeline.append(BenchmarkWriter(stream=bdata).get_iter)

--- a/testflo/util.py
+++ b/testflo/util.py
@@ -112,6 +112,14 @@ def _get_parser():
     parser.add_argument('--disallow_skipped', action='store_true', dest='disallow_skipped',
                         help="Return exit code 2 if no tests failed but some tests are skipped.")
 
+    parser.add_argument('--show_deprecations', action='store_true', dest='show_deprecations',
+                        help="Display a list of all deprecation warnings encountered in testing.")
+    parser.add_argument('--deprecations_report', action='store', dest='deprecations_report',
+                        metavar='FILE', default=None,
+                        help='Name of deprecations report file.  Default is None.')
+    parser.add_argument('--disallow_deprecations', action='store_true', dest='disallow_deprecations',
+                        help="Raise deprecation warnings as Exceptions.")
+
     parser.add_argument('tests', metavar='test', nargs='*',
                         help='A test method, test case, module, or directory to run. If not '
                              'supplied, the current working directory is assumed.')

--- a/testflo/util.py
+++ b/testflo/util.py
@@ -116,7 +116,7 @@ def _get_parser():
                         help="Display a list of all deprecation warnings encountered in testing.")
     parser.add_argument('--deprecations_report', action='store', dest='deprecations_report',
                         metavar='FILE', default=None,
-                        help='Name of deprecations report file.  Default is None.')
+                        help='Generate a deprecations report with the given file name.  Default is None.')
     parser.add_argument('--disallow_deprecations', action='store_true', dest='disallow_deprecations',
                         help="Raise deprecation warnings as Exceptions.")
 
@@ -487,4 +487,3 @@ def elapsed_str(elapsed):
 # in python3, inspect.ismethod doesn't work as you might expect, so...
 def ismethod(obj):
     return inspect.isfunction(obj) or inspect.ismethod(obj)
-


### PR DESCRIPTION
Adds the following new options to testflo:

`--show_deprecations`:     Display a list of all deprecation warnings encountered in testing.
`--deprecations_report`:    Generate a deprecations report with the given file name.
`--disallow_deprecations`:   Raise deprecation warnings as Exceptions.