### PR TITLE
fix benchmark timestamp

### DIFF
--- a/testflo/benchmark.py
+++ b/testflo/benchmark.py
@@ -7,7 +7,7 @@ class BenchmarkWriter(object):
     """
 
     def __init__(self, stream=sys.stdout):
-        self.timestamp = time.perf_counter()
+        self.timestamp = time.time()
         self.stream = stream
 
     def get_iter(self, input_iter):


### PR DESCRIPTION
In #81, the `timestamp` recorded for a benchmark was erroneously changed to use `perf_counter()` instead of `time()`.

This timestamp is meant to be the date/time of the run and is not used for timing.