### PR TITLE
Fixed a bug with the benchmark option related to a failed subTest

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+### Summary
+
+Summary of PR.
+
+### Related Issues
+
+- Resolves #
+
+### Backwards incompatibilities
+
+None
+
+### New Dependencies
+
+None

--- a/testflo/benchmark.py
+++ b/testflo/benchmark.py
@@ -12,8 +12,15 @@ class BenchmarkWriter(object):
 
     def get_iter(self, input_iter):
         for tests in input_iter:
+            first = True
             for result in tests:
-                self._write_data(result)
+                if first:
+                    # There will only be multiple results if the test has subTests and
+                    # one or more of them failed. CPU time and memory usage stats are
+                    # for the test as a whole and all results will have the same stats,
+                    # so just use the first one.
+                    self._write_data(result)
+                    first = False
                 yield result
 
     def _write_data(self, result):

--- a/testflo/benchmark.py
+++ b/testflo/benchmark.py
@@ -11,9 +11,10 @@ class BenchmarkWriter(object):
         self.stream = stream
 
     def get_iter(self, input_iter):
-        for result in input_iter:
-            self._write_data(result)
-            yield result
+        for tests in input_iter:
+            for result in tests:
+                self._write_data(result)
+                yield result
 
     def _write_data(self, result):
         stream = self.stream

--- a/testflo/mpirun.py
+++ b/testflo/mpirun.py
@@ -44,15 +44,15 @@ if __name__ == '__main__':
         if comm.rank == 0:
             for r in results:
                 for tst in r:
-                    if not isinstance(r, Test):
+                    if not isinstance(tst, Test):
                         print("\nNot all results gathered are Test objects.  "
                               "You may have out-of-sync collective MPI calls.\n")
                         break
             total_mem_usage = 0.
             for r in results:
                 for tst in r:
-                    if isinstance(r, Test):
-                        total_mem_usage += r.memory_usage
+                    if isinstance(tst, Test):
+                        total_mem_usage += tst.memory_usage
                     break  # subtests don't track their own memory usage, so break after 1st one
             for tst in tests:
                 tst.memory_usage = total_mem_usage


### PR DESCRIPTION
### Summary

- Updated benchmark.py to handle a result with failed subTests
- Updated mpirun.py to check the Test item instead of the iterator
- Added a pull request template as used in the OpenMDAO repo

### Related Issues

- Resolves #92

### Backwards incompatibilities

None

### New Dependencies

None

