### PR TITLE
Fix bug with `disallow_skipped` option

### DIFF
--- a/testflo/main.py
+++ b/testflo/main.py
@@ -100,7 +100,7 @@ def run_pipeline(source, pipe, disallow_skipped):
 
     if n_failed > 0:
         return_code = 1
-    elif n_skipped > 1 and disallow_skipped:
+    elif n_skipped > 0 and disallow_skipped:
         return_code = 2
     else:
         return_code = 0


### PR DESCRIPTION
### Summary

I believe the logic for `--disallow_skipped` was slightly wrong, such that 0 or 1 skipped test would return 0 still, while >=2 would return 2.

### Related Issues

- None

### Backwards incompatibilities

None

### New Dependencies

None
