### PR TITLE
handle python 3.12.1 change to skip behavior

### DIFF
--- a/testflo/utresult.py
+++ b/testflo/utresult.py
@@ -76,7 +76,12 @@ class UnitTestResult(unittest.TestResult):
 
     def addSkip(self, test, reason):
         """Called when a test is skipped."""
-        resdata = self._tests[test.id()]
+        # as of Python 3.12.1, startTest is not called before processing skips
+        # we will add the test to our list without calling the super() method
+        if test.id() not in self._tests:
+            resdata = self._tests[test.id()] = _ResultData(test)
+        else:
+            resdata = self._tests[test.id()]
         resdata.status = 'SKIP'
         resdata.error = reason
         super().addSkip(test, reason)

--- a/testflo/utresult.py
+++ b/testflo/utresult.py
@@ -76,8 +76,8 @@ class UnitTestResult(unittest.TestResult):
 
     def addSkip(self, test, reason):
         """Called when a test is skipped."""
-        # as of Python 3.12.1, startTest is not called before processing skips
-        # we will add the test to our list without calling the super() method
+        # as of Python 3.12.1, startTest is not called before processing skips, so we
+        # will add the test to our list without calling the super() startTest method
         if test.id() not in self._tests:
             resdata = self._tests[test.id()] = _ResultData(test)
         else:

--- a/testflo/utresult.py
+++ b/testflo/utresult.py
@@ -77,7 +77,7 @@ class UnitTestResult(unittest.TestResult):
     def addSkip(self, test, reason):
         """Called when a test is skipped."""
         # as of Python 3.12.1, startTest is not called before processing skips, so we
-        # will add the test to our list without calling the super() startTest method
+        # add the test to our list without having called the super() startTest method
         if test.id() not in self._tests:
             resdata = self._tests[test.id()] = _ResultData(test)
         else:


### PR DESCRIPTION
### Summary

As of Python 3.12.1, startTest is not called before processing skips, so we
will add the test to our list without calling the super() startTest method

### Related Issues

- Resolves #99

### Backwards incompatibilities

None

### New Dependencies

None
