### PR TITLE
Fixed handling of --skip_dirs arg

### DIFF
--- a/testflo/main.py
+++ b/testflo/main.py
@@ -120,8 +120,6 @@ def main(args=None):
 
     nprocs = options.num_procs
 
-    options.skip_dirs = []
-
     # read user prefs from ~/.testflo file.
     # create one if it doesn't exist
     homedir = os.path.expanduser('~')
@@ -131,6 +129,7 @@ def main(args=None):
             f.write("""[testflo]
 skip_dirs=site-packages,
     dist-packages,
+    __pycache__,
     build,
     _build,
     contrib

--- a/testflo/util.py
+++ b/testflo/util.py
@@ -446,7 +446,9 @@ def read_config_file(cfgfile, options):
                 typ = lambda x: x
 
             if isinstance(action, _AppendAction):
-                setattr(options, name, [typ(s.strip()) for s in optstr.split(',') if s.strip()])
+                oldval =  getattr(options, name)
+                addval = [typ(s.strip()) for s in optstr.split(',') if s.strip()]
+                setattr(options, name, oldval+addval)
             else:
                 setattr(options, name, typ(optstr))
 


### PR DESCRIPTION
### Summary

- removed the resetting of the `skip_dirs` option to an empty list
- updated the logic in `read_config_file` to append to options that are a list instead of replacing them

Also:
- added `__pycache__` to the default `skip_dirs` list

### Related Issues

- Resolves #104 

### Backwards incompatibilities

None

### New Dependencies

None
