### PR TITLE
Fixed deprecations report to handle SubTests, Fixed duration of SubTests

### DIFF
--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -31,12 +31,12 @@ jobs:
           # test on Ubuntu
           - NAME: Ubuntu Baseline
             OS: ubuntu-latest
-            PY: '3.11'
+            PY: '3.12'
 
           # test on MacOS
           - NAME: MacOS Baseline
             OS: macos-latest
-            PY: '3.11'
+            PY: '3.12'
 
     runs-on: ${{ matrix.OS }}
 
@@ -77,7 +77,7 @@ jobs:
         run: |
           cd $HOME
 
-          testflo testflo.tests || RC=$?
+           testflo testflo.tests -vs --show_skipped --durations=5 --durations-min=0 --deprecations_report dep.txt || RC=$?
 
           if [[ $RC -ne 1 ]]; then
             echo "Expected some tests to fail."
@@ -103,6 +103,8 @@ jobs:
             echo "Expected 11 tests to be skipped."
             exit 11
           fi
+
+          grep "Deprecations Report" dep.txt
 
       - name: Run tests in serial
         run: |

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           cd $HOME
 
-          testflo testflo.tests -vs --show_skipped --durations=5 --durations-min=0 --deprecations_report dep.txt || RC=$?
+          testflo testflo.tests -n 1 -vs --show_skipped --durations=5 --durations-min=0 --deprecations_report dep.txt || RC=$?
 
           if [[ $RC -ne 1 ]]; then
             echo "Expected some tests to fail."

--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           cd $HOME
 
-           testflo testflo.tests -vs --show_skipped --durations=5 --durations-min=0 --deprecations_report dep.txt || RC=$?
+          testflo testflo.tests -vs --show_skipped --durations=5 --durations-min=0 --deprecations_report dep.txt || RC=$?
 
           if [[ $RC -ne 1 ]]; then
             echo "Expected some tests to fail."
@@ -105,12 +105,13 @@ jobs:
           fi
 
           grep "Deprecations Report" dep.txt
+          rm dep.txt
 
       - name: Run tests in serial
         run: |
           cd $HOME
 
-          testflo -n 1 testflo.tests || RC=$?
+          testflo testflo.tests -vs --show_skipped --durations=5 --durations-min=0 --deprecations_report dep.txt || RC=$?
 
           if [[ $RC -ne 1 ]]; then
             echo "Expected some tests to fail."
@@ -136,6 +137,9 @@ jobs:
             echo "Expected 11 tests to be skipped."
             exit 11
           fi
+
+          grep "Deprecations Report" dep.txt
+          rm dep.txt
 
       - name: Notify slack of failure
         uses: act10ns/slack@v2.0.0

--- a/testflo/deprecations.py
+++ b/testflo/deprecations.py
@@ -16,10 +16,11 @@ class DeprecationsReport(object):
 
         deprecations = {}
 
-        for test in input_iter:
-            for msg, locs in test.deprecations.items():
-                deprecations[msg] = deprecations.get(msg, set()) | locs
-            yield test
+        for tests in input_iter:
+            for test in tests:
+                for msg, locs in test.deprecations.items():
+                    deprecations[msg] = deprecations.get(msg, set()) | locs
+                yield test
 
         report = self.generate_report(deprecations)
 

--- a/testflo/test.py
+++ b/testflo/test.py
@@ -341,11 +341,13 @@ class Test(object):
                         else:
                             stream_val = ''
                         if ut_subtests:
+                            end_time = time.perf_counter()
                             for sub, err in ut_subtests:
                                 subtest = SubTest(sub._subDescription(), self.spec, self.options)
                                 subtest.status = status
                                 subtest.err_msg = stream_val + err
-                                subtest.end_time = time.perf_counter()
+                                subtest.start_time = self.start_time
+                                subtest.end_time = end_time
                                 subtest.memory_usage = get_memory_usage()
                                 subs.append(subtest)
                         else:


### PR DESCRIPTION
### Summary

- Fixed the DeprecationsReport to properly handle Test iterators
- Set `start_time` for SubTests and moved the `perf_counter` call so it is only called once to get the `end_time` for all SubTests
- Updated test workflow to use Python 3.12 and add `durations` and `deprecation_report` args to the test script

### Related Issues

- Resolves #109, #110

### Backwards incompatibilities

None

### New Dependencies

None
