### PR TITLE
Removed setuptools as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-    "setuptools",
     "coverage>=6.0",
 ]
 

--- a/testflo/test.py
+++ b/testflo/test.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import os
 import sys
+import shutil
 import time
 import warnings
 import traceback
@@ -23,11 +24,10 @@ from testflo.utresult import UnitTestResult
 from testflo.devnull import DevNull
 
 
-from distutils import spawn
 mpirun_exe = None
-if spawn.find_executable("mpirun") is not None:
+if shutil.which("mpirun") is not None:
     mpirun_exe = "mpirun"
-elif spawn.find_executable("mpiexec") is not None:
+elif shutil.which("mpiexec") is not None:
     mpirun_exe = "mpiexec"
 
 

--- a/testflo/util.py
+++ b/testflo/util.py
@@ -17,7 +17,6 @@ from os.path import join, dirname, basename, isfile,  abspath, split, splitext
 
 from argparse import ArgumentParser, _AppendAction
 
-from testflo.cover import start_coverage, stop_coverage
 
 _store = {}
 


### PR DESCRIPTION
### Summary

- Replaced `distutils.spawn.find_executable` with `shutil.which`
- Removed `setuptools` as a dependency
- Cleaned up an unused import

### Related Issues

- Resolves #114

### Backwards incompatibilities

None

### New Dependencies

None
