### PR TITLE
added current directory to sys.path during try_import to avoid any relative import failures in test files

### DIFF
--- a/testflo/test.py
+++ b/testflo/test.py
@@ -18,7 +18,7 @@ from unittest.case import _UnexpectedSuccess
 from testflo.cover import start_coverage, stop_coverage
 
 from testflo.util import get_module, ismethod, get_memory_usage, \
-                         get_testpath, _options2args
+                         get_testpath, _options2args, _testing_path
 from testflo.utresult import UnitTestResult
 from testflo.devnull import DevNull
 
@@ -44,12 +44,6 @@ class FakeComm(object):
     def __init__(self):
         self.rank = 0
         self.size = 1
-
-
-# create a copy of sys.path with an extra entry at the beginning so that
-# we can quickly replace the first entry with the curent test's dir rather
-# than constantly copying the whole sys.path
-_testing_path = ['.'] + sys.path
 
 
 @contextmanager

--- a/testflo/util.py
+++ b/testflo/util.py
@@ -19,6 +19,12 @@ from argparse import ArgumentParser, _AppendAction
 
 from testflo.cover import start_coverage, stop_coverage
 
+# create a copy of sys.path with an extra entry at the beginning so that
+# we can quickly replace the first entry with the curent test's dir rather
+# than constantly copying the whole sys.path
+_testing_path = ['.'] + sys.path
+
+
 _store = {}
 
 
@@ -337,7 +343,11 @@ _mod2file = {}  # keep track of non-pkg files to detect and flag dups
 
 
 def try_import(fname, modpath):
+    global _testing_path
     try:
+        _testing_path[0] = os.path.dirname(fname)
+        old_sys_path = sys.path
+        sys.path = _testing_path
         mod = import_module(modpath)
     except ImportError:
         # this might be a module that's not in the same
@@ -356,6 +366,8 @@ def try_import(fname, modpath):
             del sys.modules[modpath]
         finally:
             sys.path = oldpath
+    finally:
+        sys.path = old_sys_path
 
     return mod
 


### PR DESCRIPTION

### Summary

Aviary team ran into an issue where all tests in a file were being skipped because they were attempting to do a relative import of a builder file at file scope and the import was failing because the local directory was not part of sys.path at the time when the test module was first imported (during test discovery).


### Backwards incompatibilities

None

### New Dependencies

None
