### PR TITLE
Remove extra setup/teardown calls.

### DIFF
--- a/testflo/test.py
+++ b/testflo/test.py
@@ -319,12 +319,6 @@ class Test(object):
                             status, expected2 = _try_call(getattr(parent, funcname))
                         self.err_msg = errstream.getvalue()
                     else: # use unittest code to run the test and handle subtests
-                        # if tcase_setup:
-                        #     status, expected = _try_call(tcase_setup)
-                        #     if status != 'OK':
-                        #         done = True
-                        #         # tcase_teardown = None
-
                         result= UnitTestResult()
                         parent.run(result)
                         tname, data = result._tests.popitem()
@@ -352,9 +346,6 @@ class Test(object):
                     self.status = status
                     self.memory_usage = get_memory_usage()
                     self.expected_fail = expected or expected2 or expected3
-
-                    # if tcase_teardown:
-                    #     _try_call(tcase_teardown)
 
                     if mod_teardown:
                         _try_call(mod_teardown)

--- a/testflo/test.py
+++ b/testflo/test.py
@@ -319,11 +319,11 @@ class Test(object):
                             status, expected2 = _try_call(getattr(parent, funcname))
                         self.err_msg = errstream.getvalue()
                     else: # use unittest code to run the test and handle subtests
-                        if tcase_setup:
-                            status, expected = _try_call(tcase_setup)
-                            if status != 'OK':
-                                done = True
-                                tcase_teardown = None
+                        # if tcase_setup:
+                        #     status, expected = _try_call(tcase_setup)
+                        #     if status != 'OK':
+                        #         done = True
+                        #         # tcase_teardown = None
 
                         result= UnitTestResult()
                         parent.run(result)
@@ -353,8 +353,8 @@ class Test(object):
                     self.memory_usage = get_memory_usage()
                     self.expected_fail = expected or expected2 or expected3
 
-                    if tcase_teardown:
-                        _try_call(tcase_teardown)
+                    # if tcase_teardown:
+                    #     _try_call(tcase_teardown)
 
                     if mod_teardown:
                         _try_call(mod_teardown)


### PR DESCRIPTION
### Summary

I realized recently that when I added support for subtests by just letting the TestCase object handle running the test (which also handles setup and teardown), I forgot to remove the calls to setup/teardown that we were making on our side.

### Backwards incompatibilities

None

### New Dependencies

None
