### PR TITLE
Improved functionality of the -f option

### DIFF
--- a/testflo/filters.py
+++ b/testflo/filters.py
@@ -1,5 +1,8 @@
 from __future__ import print_function
 
+import os
+
+
 class TimeFilter(object):
     """This iterator saves to the specified output file only those tests
     that complete successfully in max_time seconds or less.  This output
@@ -29,13 +32,13 @@ class FailFilter(object):
         self.outfile = outfile
 
     def get_iter(self, input_iter):
-        fails = []
+        try:
+            os.remove(self.outfile)
+        except OSError:
+            pass
+
         for result in input_iter:
             if result.status == 'FAIL' and not result.expected_fail:
-                fails.append(result.spec)
+                with open(self.outfile, 'a') as f:
+                    print(result.spec, file=f)
             yield result
-
-        if fails:
-            with open(self.outfile, 'w') as f:
-                for spec in sorted(fails):
-                    print(spec, file=f)

--- a/testflo/filters.py
+++ b/testflo/filters.py
@@ -40,5 +40,9 @@ class FailFilter(object):
         for result in input_iter:
             if result.status == 'FAIL' and not result.expected_fail:
                 with open(self.outfile, 'a') as f:
-                    print(result.spec, file=f)
+                    if result.nprocs > 1:
+                        spec = f"{result.spec}  # mpi, nprocs={result.nprocs}"
+                    else:
+                        spec = result.spec
+                    print(spec, file=f)
             yield result

--- a/testflo/test.py
+++ b/testflo/test.py
@@ -51,6 +51,8 @@ def testcontext(test):
     global _testing_path
     old_sys_path = sys.path
 
+    os.environ['TESTFLO_SPEC'] = test.spec
+
     _testing_path[0] = test.test_dir
     sys.path = _testing_path
 
@@ -61,6 +63,7 @@ def testcontext(test):
         test.err_msg = traceback.format_exc()
     finally:
         sys.path = old_sys_path
+        del os.environ['TESTFLO_SPEC']
 
 
 class Test(object):

--- a/testflo/test.py
+++ b/testflo/test.py
@@ -63,7 +63,8 @@ def testcontext(test):
         test.err_msg = traceback.format_exc()
     finally:
         sys.path = old_sys_path
-        del os.environ['TESTFLO_SPEC']
+        if 'TESTFLO_SPEC' in os.environ:
+            del os.environ['TESTFLO_SPEC']
 
 
 class Test(object):


### PR DESCRIPTION
### Summary

Instead of waiting for all tests to complete in order to generate the failtests.in file, testflo now appends to that file after each failed test, so if there's an MPI hang or something that prevents completion of the testflo run, at least you'll have the names of any tests that failed prior to the hang.  Also, if the failed test is an MPI test (assuming it fails normally and doesn't hang) then a comment will be added after that line in the failtests.in file that says it's an mpi test and lists the number of procs.

Also, testflo now sets an environment variable called 'TESTFLO_SPEC' when running each test that contains the test specification string for that test.  An update to OpenMDAO will use that information to allow om_dump to send its output to a file named after the test spec.

### New Dependencies

None
